### PR TITLE
Allow Namespace objects to be weak referenced

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ ChangeLog:
       now raises a AttributeError instead of a KeyError.
     - allow initialization without arg: Namespace() is equivalent to Namespace({})
 
+- 1.4: Allow Namespace objects to be weak referenced
 
 Developping
 -----------

--- a/dictns.py
+++ b/dictns.py
@@ -13,7 +13,7 @@ class Namespace(dict):
     input should always be json-able but this is checked only in pedentic mode, for
     obvious performance reason
     """
-    __slots__ = []
+    __slots__ = ['__weakref__']
 
     def __init__(self, d=None):
         if d is None:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ to install the package from the source archive.
 
 from setuptools import setup
 
-version = "1.3"
+version = "1.4"
 
 if __name__ == "__main__":
     extraArguments = {

--- a/test/test_namespace.py
+++ b/test/test_namespace.py
@@ -6,6 +6,7 @@ except ImportError:
 import pickle
 import json
 import collections
+import weakref
 
 from textwrap import dedent
 from copy import deepcopy, copy
@@ -205,6 +206,10 @@ class TestNamespace(unittest.TestCase):
         nsordered = Namespace(ordered)
         # still not ordered...
         self.assertNotEqual(999, nsordered.values()[-1])
+
+    def testWeakref(self):
+        n = Namespace({'a': {'b': {'c': 1}}})
+        weakref.ref(n)
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(TestNamespace)


### PR DESCRIPTION
See the **slots** documentation for more details:
https://docs.python.org/2/reference/datamodel.html#slots

Signed-off-by: Olivier Monnier olivier.monnier@intel.com
