### PR TITLE
remove the *not* ordered test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build
 *.pyc
 _trial_temp
 dist

--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,21 @@
-# dictns [![Build Status](https://travis-ci.org/tardyp/dictns.png?branch=master)](https://travis-ci.org/tardyp/dictns)
+######
+dictns
+######
+
+
+ .. image:: https://travis-ci.org/tardyp/dictns.png?branch=master
+     :target: https://travis-ci.org/tardyp/dictns
+
 
 simple python class that merges dictionary and object APIs
 
 Those Namespace objects work in a similar way as javascript objects.
 intended to help deadling with deep json objects, and save you a lot of [''] in your code
 
-usage:
+usage
+-----
+
+.. code-block:: python
 
     from dictns import Namespace
     n = Namespace(dict(a=1, b=3, c=dict(d=4)))
@@ -13,6 +23,8 @@ usage:
     assert(n['c']['d'] == n.c.d)
 
 you can wrap dicts and lists inside Namespace
+
+.. code-block:: python
 
     n = Namespace([dict(a=1, b=3, c=[dict(d=4)])])
     assert(n[0]['a'] == n[0].a)
@@ -37,6 +49,10 @@ ChangeLog:
     - Allow initialization without arg: Namespace() is equivalent to Namespace({}).
 
 - 1.4: Allow Namespace objects to be weak referenced
+
+- 1.5:
+    - Fix tests for 3.5 and pypy
+    - Readme cleanups
 
 Developing
 ----------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -6,31 +6,13 @@ Run:
 to install the package from the source archive.
 """
 
+import os
+
 from setuptools import setup
 
-version = "1.4"
+version = "1.5"
 
 if __name__ == "__main__":
-    extraArguments = {
-        'classifiers': [
-            """License :: OSI Approved :: BSD License""",
-            """Programming Language :: Python""",
-            """Topic :: Software Development :: Libraries :: Python Modules""",
-            """Intended Audience :: Developers""",
-        ],
-        'keywords': 'dict, object',
-        'long_description': """simple class that merges dictionary and object API
-
-This Namespace objects work in a similar way as javascript objects.
-usage:
-    from dictns import Namespace
-    n = Namespace(dict(a=1, b=3, c=dict(d=4)))
-    assert(n['a'] == n.a)
-    assert(n['c']['d'] == n.c.d)
-""",
-        'platforms': ['Any'],
-    }
-    # Now the actual set up call
     setup(
         name="dictns",
         version=version,
@@ -45,5 +27,13 @@ usage:
         py_modules=[
             'dictns',
         ],
-        **extraArguments
+        classifiers=[
+            """License :: OSI Approved :: BSD License""",
+            """Programming Language :: Python""",
+            """Topic :: Software Development :: Libraries :: Python Modules""",
+            """Intended Audience :: Developers""",
+        ],
+        keywords='dict, object',
+        long_description=open(os.path.join(os.path.dirname(__file__), "README.rst")).read(),
+        platforms=['Any'],
     )

--- a/test/test_namespace.py
+++ b/test/test_namespace.py
@@ -3,17 +3,14 @@ try:
 except ImportError:
     import unittest
 
-import pickle
-import json
 import collections
+import json
+import pickle
 import weakref
-
+from copy import copy, deepcopy
 from textwrap import dedent
-from copy import deepcopy, copy
-from dictns import compareNamespace
-from dictns import documentNamespace
-from dictns import filterDelta
-from dictns import Namespace
+
+from dictns import Namespace, compareNamespace, documentNamespace, filterDelta
 
 
 class TestNamespace(unittest.TestCase):
@@ -190,22 +187,7 @@ class TestNamespace(unittest.TestCase):
         ordered = collections.OrderedDict([("a", "b"), ("c", "d")])
         nsordered = Namespace(ordered)
         self.assertEqual(nsordered.a, ordered["a"])
-        self.assertEqual(nsordered.c, nsordered.values()[-1])
-        ordered['e'] = 'f'
-        self.assertEqual(nsordered.c, nsordered.values()[-1])
-        nsordered['e'] = 'f'
-        self.assertEqual(nsordered.e, nsordered.values()[-1])
-        for i in xrange(1000):
-            nsordered[str(i)] = i
-            ordered[str(i)] = i
-
-        # Namespace of an OrderedDict is *not* ordered
-        self.assertEqual(999, ordered.values()[-1])
-        self.assertNotEqual(999, nsordered.values()[-1])
-
-        nsordered = Namespace(ordered)
-        # still not ordered...
-        self.assertNotEqual(999, nsordered.values()[-1])
+        self.assertEqual(nsordered.c, list(nsordered.values())[-1])
 
     def testWeakref(self):
         n = Namespace({'a': {'b': {'c': 1}}})

--- a/test/test_namespace.py
+++ b/test/test_namespace.py
@@ -187,7 +187,6 @@ class TestNamespace(unittest.TestCase):
         ordered = collections.OrderedDict([("a", "b"), ("c", "d")])
         nsordered = Namespace(ordered)
         self.assertEqual(nsordered.a, ordered["a"])
-        self.assertEqual(nsordered.c, list(nsordered.values())[-1])
 
     def testWeakref(self):
         n = Namespace({'a': {'b': {'c': 1}}})


### PR DESCRIPTION
dictionary ordering is implementation dependend.
We cannot just assert tht the last is not in the last, as perhaps some implementation by chance will put it in the last position.